### PR TITLE
Fix for AES keys in `saves/Citra/sysdata/`

### DIFF
--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -318,6 +318,16 @@ void UpdateSettings() {
                 FileUtil::GetUserPath(FileUtil::UserPath::RootDir, target_dir);
                 const auto& target_dir_result = FileUtil::GetUserPath(FileUtil::UserPath::UserDir, target_dir);
                 LOG_INFO(Frontend, "User dir set to \"{}\".", target_dir_result);
+
+                // Update sysdata path as well, used for the AES keys for example
+                target_dir += "/sysdata/";
+
+                if (!FileUtil::CreateDir(target_dir)) {
+                    LOG_ERROR(Frontend, "Failed to create \"{}\". Using Citra's default path for the 'sysdata' folder.", target_dir);
+                } else {
+                    const auto& target_sysdata_dir = FileUtil::GetUserPath(FileUtil::UserPath::SysDataDir, target_dir);
+                    LOG_INFO(Frontend, "Sysdata dir set to \"{}\".", target_sysdata_dir);
+                }
             }
         }
     }


### PR DESCRIPTION
This allows loading encrypted games without having to use the standalone path. Now `saves/Citra/sysdata/aes_keys.txt` should be read properly when the "Savegame location" core option is set to "LibRetro Default". If it's set to "Citra Default" or if the "sysdata" can't be created it will fall back to standalone path.

Tested on Windows 10 and on my Linux Mint VM, no issue, encrypted games loaded without any issue using the Libretro folder!

Closes #1 